### PR TITLE
Clean up the Travis build so that it passes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: python
 python: 2.7
 env:
-  - TOX_ENV=py26
-  - TOX_ENV=py27
-  - TOX_ENV=django-celery-2.X
-  - TOX_ENV=django-1.3.X
+  - TOX_ENV=py26-django1.4.X-djangocelery2.5.X-celery2.5.X
+  - TOX_ENV=py27-django1.4.X-djangocelery2.5.X-celery2.5.X
+  - TOX_ENV=flake8
 install: pip install tox
 script: tox -e $TOX_ENV

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+0.3.0
+-----
+
+* Dropped support for Django 1.3.
+  It's no longer getting security updates.
+
 0.2.2
 -----
 

--- a/README.md
+++ b/README.md
@@ -448,12 +448,12 @@ but if it persists, you'll want to give your user feedback.
 ## Running The Test Suite
 
 We use [tox](https://tox.readthedocs.org/en/latest/)
-to run our tests again various combinations
+to run our tests against various combinations
 of python/Django/Celery.
 We only officially support
 the combinations listed in our `.travis.yml` file,
 but we're working on
-(checkout out [Issue 33](https://github.com/PolicyStat/jobtastic/issues/33))
+([Issue 33](https://github.com/PolicyStat/jobtastic/issues/33))
 supporting everything defined in `tox.ini`.
 Until then,
 you can run tests against supported combos with:

--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ You could write all of the stuff yourself, but why?
    so that you can build [psutil](http://psutil.googlecode.com/hg/INSTALL).
 
   On Ubuntu, that means running:
-  
+
   `$ sudo apt-get install build-essential python-dev`
-  
+
   On OS X, you'll need to run the "XcodeTools" installer.
-  
+
 2. Get the project source and install it
 
     `$ pip install jobtastic`
@@ -447,19 +447,24 @@ but if it persists, you'll want to give your user feedback.
 
 ## Running The Test Suite
 
-You can run Jobtastic's test suite yourself via:
+We use [tox](https://tox.readthedocs.org/en/latest/)
+to run our tests again various combinations
+of python/Django/Celery.
+We only officially support
+the combinations listed in our `.travis.yml` file,
+but we're working on
+(checkout out [Issue 33](https://github.com/PolicyStat/jobtastic/issues/33))
+supporting everything defined in `tox.ini`.
+Until then,
+you can run tests against supported combos with:
 
-    $ python setup.py test
+    $ pip install tox
+    $ tox -e py26-django1.4.X-djangocelery2.5.X-celery2.5.X
 
 Our test suite currently only tests usage with Django,
 which is definitely a [bug](https://github.com/PolicyStat/jobtastic/issues/15).
 Especially if you use Jobtastic with Flask,
 we would love a pull request.
-
-You can also run tests
-across all of our supported python/Django/Celery versions via Tox:
-
-    $ tox
 
 ## Dynamic Time Estimates via JobtasticMixins
 

--- a/jobtastic/__init__.py
+++ b/jobtastic/__init__.py
@@ -1,6 +1,6 @@
 """Make your user-facing Celery jobs totally awesomer"""
 
-VERSION = (0, 2, 2, '')
+VERSION = (0, 3, 0, 'dev')
 __version__ = '.'.join(map(str, VERSION[0:3])) + ''.join(VERSION[3:])
 __author__ = 'Wes Winham'
 __contact__ = 'winhamwr@gmail.com'

--- a/jobtastic/__init__.py
+++ b/jobtastic/__init__.py
@@ -14,4 +14,4 @@ __all__ = (
 
 # -eof meta-
 
-from jobtastic.task import JobtasticTask
+from jobtastic.task import JobtasticTask  # NOQA

--- a/jobtastic/task.py
+++ b/jobtastic/task.py
@@ -54,7 +54,7 @@ if cache is None:
         "Jobtastic requires either Django or Flask + Memcached result backend")
 
 
-from jobtastic.states import PROGRESS
+from jobtastic.states import PROGRESS  # NOQA
 
 
 @contextmanager

--- a/jobtastic/tests/test_broker_fallbacks.py
+++ b/jobtastic/tests/test_broker_fallbacks.py
@@ -13,20 +13,23 @@ except ImportError:
 from jobtastic.tests.utils import eager_tasks
 from jobtastic import JobtasticTask
 
-USING_CELERY_2_X = False
 try:
     from kombu.transport.pyamqp import (
         Channel as AmqpChannel,
     )
-    from kombu.exceptions import StdChannelError, StdConnectionError
 except ImportError:
-    USING_CELERY_2_X = True
     from kombu.transport.amqplib import (
         Channel as AmqpChannel,
     )
+# Kombu>=2.1 doesn't have StdConnectionError or StdChannelError, but the 2.1
+# amqp Transport uses an IOError, so we'll just test with that.
+try:
     from kombu.exceptions import StdChannelError
-    # Kombu 2.1 doesn' thave a StdConnectionError, but the 2.1 amqp Transport
-    # uses an IOError, so we'll just test with that
+except ImportError:
+    StdChannelError = IOError
+try:
+    from kombu.exceptions import StdChannelError
+except ImportError:
     StdConnectionError = IOError
 
 

--- a/jobtastic/tests/test_broker_fallbacks.py
+++ b/jobtastic/tests/test_broker_fallbacks.py
@@ -11,6 +11,7 @@ except ImportError:
     from celery.tests.case import AppCase
 # eager_tasks was removed in celery 3.1
 from jobtastic.tests.utils import eager_tasks
+from jobtastic import JobtasticTask
 
 USING_CELERY_2_X = False
 try:
@@ -27,8 +28,6 @@ except ImportError:
     # Kombu 2.1 doesn' thave a StdConnectionError, but the 2.1 amqp Transport
     # uses an IOError, so we'll just test with that
     StdConnectionError = IOError
-
-from jobtastic import JobtasticTask
 
 
 class ParrotTask(JobtasticTask):

--- a/jobtastic/tests/test_broker_fallbacks.py
+++ b/jobtastic/tests/test_broker_fallbacks.py
@@ -28,7 +28,7 @@ try:
 except ImportError:
     StdChannelError = IOError
 try:
-    from kombu.exceptions import StdChannelError
+    from kombu.exceptions import StdConnectionError
 except ImportError:
     StdConnectionError = IOError
 

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,2 +1,2 @@
-celery>=2.5,<3.1
 psutil
+celery>=2.5,<4

--- a/requirements/test_celery_2_X.txt
+++ b/requirements/test_celery_2_X.txt
@@ -1,4 +1,0 @@
-celery>=2.5,<3.0
-psutil
-unittest2
-mock

--- a/requirements/test_celery_default.txt
+++ b/requirements/test_celery_default.txt
@@ -1,5 +1,0 @@
-celery>=2.5,<3.1
-psutil
-unittest2
-mock
-

--- a/requirements/test_django_1_3_X.txt
+++ b/requirements/test_django_1_3_X.txt
@@ -1,4 +1,0 @@
-django>=1.3,<1.4
-django-celery
-django-nose
-

--- a/requirements/test_django_celery_2_X.txt
+++ b/requirements/test_django_celery_2_X.txt
@@ -1,4 +1,0 @@
-django>=1.3,<=1.5
-django-celery<3.0
-django-nose
-

--- a/requirements/test_django_default.txt
+++ b/requirements/test_django_default.txt
@@ -1,4 +1,0 @@
-django>=1.3,<=1.5
-django-celery
-django-nose
-

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,0 +1,3 @@
+django-nose
+unittest2
+mock

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,3 +1,4 @@
+django
 django-nose
 unittest2
 mock

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,4 +1,3 @@
-django
 django-nose
 unittest2
 mock

--- a/setup.py
+++ b/setup.py
@@ -95,6 +95,7 @@ def reqs(*f):
         os.path.join(os.getcwd(), 'requirements', *f)).readlines()]))
 
 install_requires = reqs('default.txt')
+tests_require = reqs('tests.txt')
 
 # -*- Test Runners -*-
 
@@ -152,4 +153,5 @@ setup(
         'test': RunDjangoTests,
     },
     install_requires=install_requires,
+    tests_require=tests_require,
 )

--- a/setup.py
+++ b/setup.py
@@ -116,19 +116,28 @@ class RunDjangoTests(Command):
         os.chdir(django_testproj_dir)
         sys.path.append(django_testproj_dir)
 
-        from django.core.management import execute_manager
         os.environ['DJANGO_SETTINGS_MODULE'] = os.environ.get(
             'DJANGO_SETTINGS_MODULE',
             'testproj.settings',
         )
-        settings_file = os.environ['DJANGO_SETTINGS_MODULE']
-        settings_mod = __import__(settings_file, {}, {}, [''])
-        prev_argv = list(sys.argv)
+
+        django_1_4 = False
         try:
-            sys.argv = [__file__, 'test'] + self.extra_args
-            execute_manager(settings_mod, argv=sys.argv)
-        finally:
-            sys.argv = prev_argv
+            from django.core.management import execute_manager as run_command
+            django_1_4 = True
+        except ImportError:
+            # execute_manager was renamed in Django 1.6
+            from django.core.management import (
+                execute_from_command_line as run_command,
+            )
+
+        modified_args = [__file__, 'test'] + self.extra_args
+        if django_1_4:
+            settings_file = os.environ['DJANGO_SETTINGS_MODULE']
+            settings_mod = __import__(settings_file, {}, {}, [''])
+            run_command(settings_mod, argv=modified_args)
+        else:
+            run_command(modified_args)
 
     def initialize_options(self):
         pass

--- a/tox.ini
+++ b/tox.ini
@@ -1,23 +1,21 @@
 [tox]
-envlist = py26,py27,django-celery-2.X,django-1.3.X
+envlist =
+	py{26,27}-django{1.4.X,1.6.X,1.7.X}-djangocelery{3.0.X,3.1.X},
+	py{26,27}-django{1.4.X,1.6.X,1.7.X}-djangocelery2.5.X-celery2.5.X,
+	flake8
 
 [testenv]
 commands = {envpython} setup.py test
-deps = -r{toxinidir}/requirements/test_celery_default.txt
-       -r{toxinidir}/requirements/test_django_default.txt
+deps =
+	-r{toxinidir}/requirements/tests.txt
+	celery2.5.X: celery==2.5
+	djangocelery2.5.X: django-celery==2.5
+	djangocelery3.0.X: django-celery==3.0
+	djangocelery3.1.X: django-celery==3.1
+	django1.4.X: django==1.4
+	django1.6.X: django==1.6
+	django1.7.X: django==1.7
 
-[testenv:py26]
-basepython = python2.6
-
-[testenv:py27]
-basepython = python2.7
-
-[testenv:django-celery-2.X]
-basepython = python2.6
-deps = -r{toxinidir}/requirements/test_celery_2_X.txt
-       -r{toxinidir}/requirements/test_django_celery_2_X.txt
-
-[testenv:django-1.3.X]
-basepython = python2.6
-deps = -r{toxinidir}/requirements/test_celery_default.txt
-       -r{toxinidir}/requirements/test_django_1_3_X.txt
+[testenv:flake8]
+deps=flake8
+commands = flake8 jobtastic

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
 	py{26,27}-django{1.4.X,1.6.X,1.7.X}-djangocelery{3.0.X,3.1.X},
-	py{26,27}-django{1.4.X,1.6.X,1.7.X}-djangocelery2.5.X-celery2.5.X,
+	py{26,27}-django1.4.X-djangocelery2.5.X-celery2.5.X,
 	flake8
 
 [testenv]


### PR DESCRIPTION
* Only test against supported versions of things
* Make sure we're using compatible versions of django-celery and celery.
* Use the generative environments in tox1.8 to reduce typing
* Add all of the things we'd like to support to tox (all the versions of django and celery), but don't add those to travis
* Add flake8 to travis