### PR TITLE
Python 3.4 Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ pip-log.txt
 
 #Mr Developer
 .mr.developer.cfg
+
+#Pycharm IDE settings
+.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,20 @@ env:
   - TOX_ENV=py27-django1.7.X-djangocelery3.0.X
   - TOX_ENV=py27-django1.7.X-djangocelery3.1.X
   - TOX_ENV=py27-django1.8.X-djangocelery3.1.X
+  - TOX_ENV=py34-django1.7.X-djangocelery3.1.X
+  - TOX_ENV=py34-django1.8.X-djangocelery3.1.X
+  - TOX_ENV=py27-django1.9.X-djangocelery3.1.X
+  - TOX_ENV=py34-django1.9.X-djangocelery3.1.X
+  - TOX_ENV=py26-django1.4.X-celery3.1.X
+  - TOX_ENV=py26-django1.6.X-celery3.1.X
+  - TOX_ENV=py27-django1.4.X-celery3.1.X
+  - TOX_ENV=py27-django1.6.X-celery3.1.X
+  - TOX_ENV=py27-django1.7.X-celery3.1.X
+  - TOX_ENV=py27-django1.8.X-celery3.1.X
+  - TOX_ENV=py34-django1.7.X-celery3.1.X
+  - TOX_ENV=py34-django1.8.X-celery3.1.X
+  - TOX_ENV=py27-django1.9.X-celery3.1.X
+  - TOX_ENV=py34-django1.9.X-celery3.1.X
   - TOX_ENV=flake8
 install: pip install tox
 script: tox -e $TOX_ENV

--- a/jobtastic/task.py
+++ b/jobtastic/task.py
@@ -435,7 +435,12 @@ class JobtasticTask(Task):
         m = md5()
         for significant_kwarg in self.significant_kwargs:
             key, to_str = significant_kwarg
-            m.update(to_str(kwargs[key]))
+            try:
+                m.update(to_str(kwargs[key]))
+            except TypeError:
+                # Python 3.x strings aren't accepted by hash.update().
+                # String should be byte-encoded first.
+                m.update(to_str(kwargs[key]).encode('utf-8'))
 
         if hasattr(self, 'cache_prefix'):
             cache_prefix = self.cache_prefix

--- a/jobtastic/tests/test_broker_fallbacks.py
+++ b/jobtastic/tests/test_broker_fallbacks.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 
 import mock
@@ -106,7 +107,7 @@ class BrokenBrokerTestCase(AppCase):
         except KeyError:
             pass  # Celery 2.5
         else:
-            print result
+            print(result)
             raise AssertionError('Exception should have been raised')
 
     @error_if_calculate_result_patch

--- a/jobtastic/tests/test_progress.py
+++ b/jobtastic/tests/test_progress.py
@@ -1,4 +1,7 @@
-
+try:
+    import xrange  # Python 2
+except ImportError:
+    import range as xrange  # Python 3
 import mock
 
 from celery.result import BaseAsyncResult

--- a/test_projects/django/testproj/settings.py
+++ b/test_projects/django/testproj/settings.py
@@ -42,12 +42,15 @@ INSTALLED_APPS = (
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.sites',
-    'djcelery',
     'testproj.someapp',
     'jobtastic',
     'django_nose',
 )
-
+try:
+    import djcelery
+    INSTALLED_APPS += ('djcelery', )
+except ImportError:
+    pass
 
 NOSE_ARGS = [
     os.path.join(here, os.pardir, os.pardir, os.pardir, 'jobtastic', 'tests'),

--- a/test_projects/django/testproj/someapp/tasks.py
+++ b/test_projects/django/testproj/someapp/tasks.py
@@ -1,8 +1,14 @@
 import string
 import random
 
+from django.utils import six
+
 from jobtastic import JobtasticTask
 
+if six.PY3:
+    per_character_factor = 4  # py3 unicode characters take less memory
+else:
+    per_character_factor = 1
 leaky_global = []
 
 
@@ -21,12 +27,12 @@ class BaseMemLeakyTask(JobtasticTask):
         """
         global leaky_global
 
-        for _ in xrange(bloat_factor):
+        for _ in six.moves.range(bloat_factor):
             # 1 million bytes for a MB
-            new_str = u'X' * 1000000
+            new_str = u'X' * (1000000 * per_character_factor)
             # Add something new to it so python can't just point to the same
             # memory location
-            new_str += random.choice(string.letters)
+            new_str += random.choice(string.ascii_letters)
             leaky_global.append(new_str)
 
         return bloat_factor

--- a/test_projects/django/testproj/urls.py
+++ b/test_projects/django/testproj/urls.py
@@ -1,8 +1,10 @@
 from django.conf.urls import patterns, include, url
 
-from djcelery.views import apply
-
-urlpatterns = patterns('',
-    url(r'^apply/(?P<task_name>.+?)/', apply, name='celery-apply'),
-    url(r'^celery/', include('djcelery.urls')),
-)
+try:
+    from djcelery.views import apply
+    urlpatterns = patterns('',
+        url(r'^apply/(?P<task_name>.+?)/', apply, name='celery-apply'),
+        url(r'^celery/', include('djcelery.urls')),
+    )
+except ImportError:
+    urlpatterns = patterns('')

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,9 @@
 envlist =
 	py{26,27}-django{1.4.X,1.6.X}-djangocelery{3.0.X,3.1.X},
 	py{26,27}-django1.4.X-djangocelery2.5.X-celery2.5.X,
-	py{27}-django{1.7.X,1.8.X}-djangocelery{3.1.X},
+	py{27,34}-django{1.7.X,1.8.X,1.9.X}-djangocelery{3.1.X},
+	py{26,27}-django{1.4.X,1.6.X}-celery3.1.X,
+	py{27,34}-django{1.7.X,1.8.X,1.9.X}-celery3.1.X,
 	flake8
 
 [testenv]
@@ -10,6 +12,7 @@ commands = {envpython} setup.py test
 deps =
 	-r{toxinidir}/requirements/tests.txt
 	celery2.5.X: celery>=2.5,<2.6
+	celery3.1.X: celery>=3.1,<3.2
 	djangocelery2.5.X: django-celery>=2.5,<2.6
 	djangocelery3.0.X: django-celery>=3.0,<3.0.21
 	djangocelery3.1.X: django-celery>=3.1,<3.2
@@ -17,6 +20,7 @@ deps =
 	django1.6.X: django>=1.6,<1.7
 	django1.7.X: django>=1.7,<1.8
 	django1.8.X: django>=1.8,<1.9
+	django1.9.X: django>=1.9,<1.10
 
 [testenv:flake8]
 deps=flake8


### PR DESCRIPTION
Updated module code and test code (mostly test code) to work on python 3.4.
Added python 3.4 testing environments for django versions which support it.
Also expanded testing environments to include django 1.9, and testing with celery 3.1 without django-celery.