### PR TITLE
Drop support for old versions of python/django/celery

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,17 @@ language: python
 sudo: false
 python: 3.5
 env:
+  - TOX_ENV=py27-django1.6.X-djangocelery3.1.X
+  - TOX_ENV=py27-django1.7.X-djangocelery3.1.X
   - TOX_ENV=py27-django1.8.X-djangocelery3.1.X
-  - TOX_ENV=py34-django1.8.X-djangocelery3.1.X
   - TOX_ENV=py27-django1.9.X-djangocelery3.1.X
-  - TOX_ENV=py34-django1.9.X-djangocelery3.1.X
-  - TOX_ENV=py27-django1.8.X-celery3.1.X
-  - TOX_ENV=py34-django1.8.X-celery3.1.X
-  - TOX_ENV=py27-django1.9.X-celery3.1.X
-  - TOX_ENV=py34-django1.9.X-celery3.1.X
   - TOX_ENV=py35-django1.8.X-djangocelery3.1.X
-  - TOX_ENV=py35-django1.8.X-celery3.1.X
   - TOX_ENV=py35-django1.9.X-djangocelery3.1.X
+  - TOX_ENV=py27-django1.6.X-celery3.1.X
+  - TOX_ENV=py27-django1.7.X-celery3.1.X
+  - TOX_ENV=py27-django1.8.X-celery3.1.X
+  - TOX_ENV=py27-django1.9.X-celery3.1.X
+  - TOX_ENV=py35-django1.8.X-celery3.1.X
   - TOX_ENV=py35-django1.9.X-celery3.1.X
   - TOX_ENV=flake8
 install: pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,30 +2,11 @@ language: python
 sudo: false
 python: 3.5
 env:
-  - TOX_ENV=py26-django1.4.X-djangocelery2.5.X-celery2.5.X
-  - TOX_ENV=py27-django1.4.X-djangocelery2.5.X-celery2.5.X
-  - TOX_ENV=py26-django1.4.X-djangocelery3.0.X
-  - TOX_ENV=py26-django1.4.X-djangocelery3.1.X
-  - TOX_ENV=py26-django1.6.X-djangocelery3.0.X
-  - TOX_ENV=py26-django1.6.X-djangocelery3.1.X
-  - TOX_ENV=py27-django1.4.X-djangocelery3.0.X
-  - TOX_ENV=py27-django1.4.X-djangocelery3.1.X
-  - TOX_ENV=py27-django1.6.X-djangocelery3.0.X
-  - TOX_ENV=py27-django1.6.X-djangocelery3.1.X
-  - TOX_ENV=py27-django1.7.X-djangocelery3.0.X
-  - TOX_ENV=py27-django1.7.X-djangocelery3.1.X
   - TOX_ENV=py27-django1.8.X-djangocelery3.1.X
-  - TOX_ENV=py34-django1.7.X-djangocelery3.1.X
   - TOX_ENV=py34-django1.8.X-djangocelery3.1.X
   - TOX_ENV=py27-django1.9.X-djangocelery3.1.X
   - TOX_ENV=py34-django1.9.X-djangocelery3.1.X
-  - TOX_ENV=py26-django1.4.X-celery3.1.X
-  - TOX_ENV=py26-django1.6.X-celery3.1.X
-  - TOX_ENV=py27-django1.4.X-celery3.1.X
-  - TOX_ENV=py27-django1.6.X-celery3.1.X
-  - TOX_ENV=py27-django1.7.X-celery3.1.X
   - TOX_ENV=py27-django1.8.X-celery3.1.X
-  - TOX_ENV=py34-django1.7.X-celery3.1.X
   - TOX_ENV=py34-django1.8.X-celery3.1.X
   - TOX_ENV=py27-django1.9.X-celery3.1.X
   - TOX_ENV=py34-django1.9.X-celery3.1.X

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ You could write all of the stuff yourself, but why?
 
   On Ubuntu, that means running:
 
-  `$ sudo apt-get install build-essential python-dev python2.6-dev python2.7-dev rabbitmq-server`
+  `$ sudo apt-get install build-essential python-dev python2.7-dev rabbitmq-server`
 
   On OS X, you'll need to run the "XcodeTools" installer.
 
@@ -459,7 +459,7 @@ Until then,
 you can run tests against supported combos with:
 
     $ pip install tox
-    $ tox -e py26-django1.4.X-djangocelery2.5.X-celery2.5.X
+    $ tox -e py27-django1.8.X-djangocelery3.1.X-celery3.1.X
 
 Our test suite currently only tests usage with Django,
 which is definitely a [bug](https://github.com/PolicyStat/jobtastic/issues/15).
@@ -488,7 +488,7 @@ Yes. Increasingly so.
 ## Project Status
 
 Jobtastic is currently known to work
-with Django 1.3-1.5 and Celery 2.5-3.0.
+with Django 1.8+ and Celery 3.1.
 The goal is to support those versions and newer.
 Please file issues if there are problems
 with newer versions of Django/Celery.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ You could write all of the stuff yourself, but why?
 
   On Ubuntu, that means running:
 
-  `$ sudo apt-get install build-essential python-dev python2.7-dev rabbitmq-server`
+  `$ sudo apt-get install build-essential python-dev python2.7-dev python3.5-dev rabbitmq-server`
 
   On OS X, you'll need to run the "XcodeTools" installer.
 
@@ -488,7 +488,7 @@ Yes. Increasingly so.
 ## Project Status
 
 Jobtastic is currently known to work
-with Django 1.8+ and Celery 3.1.
+with Django 1.6+ and Celery 3.1.X
 The goal is to support those versions and newer.
 Please file issues if there are problems
 with newer versions of Django/Celery.

--- a/jobtastic/__init__.py
+++ b/jobtastic/__init__.py
@@ -1,6 +1,6 @@
 """Make your user-facing Celery jobs totally awesomer"""
 
-VERSION = (0, 3, 1, '')
+VERSION = (1, 0, 0, 'a1')
 __version__ = '.'.join(map(str, VERSION[0:3])) + ''.join(VERSION[3:])
 __author__ = 'Wes Winham'
 __contact__ = 'winhamwr@gmail.com'

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,2 +1,2 @@
 psutil>=3.0,<4
-celery>=2.5,<4
+celery>=3.1,<4

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,4 +1,4 @@
-django-nose
+django-nose==1.4.3  # 1.4.4 drops django <1.8 support
 unittest2
 mock
 django-picklefield==0.3.1

--- a/setup.py
+++ b/setup.py
@@ -121,12 +121,10 @@ class RunDjangoTests(Command):
             'testproj.settings',
         )
 
-        from django.core.management import (
-            execute_from_command_line as run_command,
-        )
+        from django.core.management import execute_from_command_line
 
         modified_args = [__file__, 'test'] + self.extra_args
-        run_command(modified_args)
+        execute_from_command_line(modified_args)
 
     def initialize_options(self):
         pass

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import codecs
 import os
 import sys
 
-from setuptools import setup, Command
+from setuptools import setup, find_packages, Command
 
 long_description = codecs.open("README.md", "r", "utf-8").read()
 
@@ -143,7 +143,7 @@ setup(
     author_email=meta['contact'],
     url=meta['homepage'],
     long_description=long_description,
-    packages=[NAME],
+    packages=find_packages(),
     license='BSD',
     platforms=['any'],
     classifiers=CLASSIFIERS,

--- a/setup.py
+++ b/setup.py
@@ -121,23 +121,12 @@ class RunDjangoTests(Command):
             'testproj.settings',
         )
 
-        django_1_4 = False
-        try:
-            from django.core.management import execute_manager as run_command
-            django_1_4 = True
-        except ImportError:
-            # execute_manager was renamed in Django 1.6
-            from django.core.management import (
-                execute_from_command_line as run_command,
-            )
+        from django.core.management import (
+            execute_from_command_line as run_command,
+        )
 
         modified_args = [__file__, 'test'] + self.extra_args
-        if django_1_4:
-            settings_file = os.environ['DJANGO_SETTINGS_MODULE']
-            settings_mod = __import__(settings_file, {}, {}, [''])
-            run_command(settings_mod, argv=modified_args)
-        else:
-            run_command(modified_args)
+        run_command(modified_args)
 
     def initialize_options(self):
         pass

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,7 @@
 [tox]
 envlist =
-	py{26,27}-django{1.4.X,1.6.X}-djangocelery{3.0.X,3.1.X},
-	py{26,27}-django1.4.X-djangocelery2.5.X-celery2.5.X,
-	py{27,34}-django{1.7.X,1.8.X,1.9.X}-djangocelery{3.1.X},
-	py{26,27}-django{1.4.X,1.6.X}-celery3.1.X,
-	py{27,34}-django{1.7.X,1.8.X,1.9.X}-celery3.1.X,
+	py{27,34}-django{1.8.X,1.9.X}-djangocelery{3.1.X},
+	py{27,34}-django{1.8.X,1.9.X}-celery3.1.X,
 	py35-django{1.8.X,1.9.X}-djangocelery3.1.X,
 	py35-django{1.8.X,1.9.X}-celery3.1.X,
 	flake8
@@ -13,14 +10,8 @@ envlist =
 commands = {envpython} setup.py test
 deps =
 	-r{toxinidir}/requirements/tests.txt
-	celery2.5.X: celery>=2.5,<2.6
 	celery3.1.X: celery>=3.1,<3.2
-	djangocelery2.5.X: django-celery>=2.5,<2.6
-	djangocelery3.0.X: django-celery>=3.0,<3.0.21
 	djangocelery3.1.X: django-celery>=3.1,<3.2
-	django1.4.X: django>=1.4,<1.5
-	django1.6.X: django>=1.6,<1.7
-	django1.7.X: django>=1.7,<1.8
 	django1.8.X: django>=1.8,<1.9
 	django1.9.X: django>=1.9,<1.10
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-	py{27,34}-django{1.8.X,1.9.X}-djangocelery{3.1.X},
-	py{27,34}-django{1.8.X,1.9.X}-celery3.1.X,
+	py27-django{1.6.X,1.7.X,1.8.X,1.9.X}-djangocelery3.1.X,
+	py27-django{1.6.X,1.7.X,1.8.X,1.9.X}-celery3.1.X,
 	py35-django{1.8.X,1.9.X}-djangocelery3.1.X,
 	py35-django{1.8.X,1.9.X}-celery3.1.X,
 	flake8
@@ -12,6 +12,8 @@ deps =
 	-r{toxinidir}/requirements/tests.txt
 	celery3.1.X: celery>=3.1,<3.2
 	djangocelery3.1.X: django-celery>=3.1,<3.2
+	django1.6.X: django>=1.6,<1.7
+	django1.7.X: django>=1.7,<1.8
 	django1.8.X: django>=1.8,<1.9
 	django1.9.X: django>=1.9,<1.10
 


### PR DESCRIPTION
We only need to support:

* django 1.6+
* Celery 3.1+
* python 2.7
* python 3.5

The old versions of django are out of their security support window.