### PR TITLE
Switch from werkzeug.contrib.cache to cachelib

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,7 +537,7 @@ A cache is now selected with the following priority:
 * If Django is installed, then:
     - If the setting is a valid Django cache entry, then use that.
     - If the setting is empty use the default cache
-* If Werkzeug is installed, then:
+* If [cachelib](https://github.com/pallets/cachelib) is installed, then:
     - If the setting is a valid Celery Memcache or Redis Backend, then use that.
     - If the setting is empty and the default Celery Result Backend is Memcache or Redis, then use that
 

--- a/jobtastic/cache/__init__.py
+++ b/jobtastic/cache/__init__.py
@@ -20,8 +20,8 @@ except ImportError:
     pass
 
 try:
-    from werkzeug.contrib.cache import MemcachedCache, RedisCache
-    CACHES.append('Werkzeug')
+    from cachelib import MemcachedCache, RedisCache
+    CACHES.append('cachelib')
 except ImportError:
     pass
 
@@ -34,7 +34,7 @@ def get_cache(app):
     Otherwise, if Django is installed, then:
         If the setting is a valid Django cache entry, then use that.
         If the setting is empty use the default cache
-    Otherwise, if Werkzeug is installed, then:
+    Otherwise, if cachelib is installed, then:
         If the setting is a valid Celery Memcache or Redis Backend, then use
             that.
         If the setting is empty and the default Celery Result Backend is
@@ -54,7 +54,7 @@ def get_cache(app):
         else:
             return WrappedCache(get_django_cache('default'))
 
-    if 'Werkzeug' in CACHES:
+    if 'cachelib' in CACHES:
         if jobtastic_cache_setting:
             backend, url = get_backend_by_url(jobtastic_cache_setting)
             backend = backend(app=app, url=url)

--- a/jobtastic/cache/base.py
+++ b/jobtastic/cache/base.py
@@ -72,7 +72,7 @@ class WrappedCache(BaseCache):
                     # Possibly using old Django-Redis
                     lock = self.cache.client.lock
                 except AttributeError:
-                    # Possibly using Werkzeug + Redis
+                    # Possibly using cachelib + Redis
                     lock = self.cache._client.lock
             have_lock = False
             lock = lock(lock_name, timeout=timeout)

--- a/jobtastic/tests/test_settings.py
+++ b/jobtastic/tests/test_settings.py
@@ -7,7 +7,7 @@ from celery.backends.cache import DummyClient
 from django.conf import settings
 from django.test import TestCase
 from jobtastic.task import JobtasticTask
-from werkzeug.contrib.cache import MemcachedCache
+from cachelib import MemcachedCache
 try:
     from django.core.cache import caches
 except ImportError:
@@ -84,9 +84,9 @@ class DjangoSettingsTestCase(TestCase):
             self.assertTrue('herd:%s' % self.key in caches['shared'])
             self.assertTrue('herd:%s' % self.key not in caches['default'])
 
-    @mock.patch('jobtastic.cache.CACHES', ['Werkzeug'])
+    @mock.patch('jobtastic.cache.CACHES', ['cachelib'])
     @mock.patch.object(DummyClient, 'add', add, create=True)
-    def test_default_werkzeug_cache(self):
+    def test_default_cachelib_cache(self):
         with self.settings(CELERY_ALWAYS_EAGER=False):
             app = Celery()
             app.config_from_object(settings)

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -3,4 +3,4 @@ unittest2
 mock
 django-picklefield
 six
-werkzeug
+cachelib


### PR DESCRIPTION
```
/jobtastic/cache/__init__.py:23: DeprecationWarning:'werkzeug.contrib.cache' is deprecated as of version 0.15 and will be removed in version 1.0. It has moved to https://github.com/pallets/cachelib.
```

[Werkzerug has removed `contrib.cache`](https://werkzeug.palletsprojects.com/en/0.16.x/transition/#deprecated-and-removed-code) from the main package, and is now being maintained as [`cachelib`](https://github.com/pallets/cachelib)


So If an app is using `werkzeug >= 1.0`, jobtastic's `Werkzeug` cache will remain unused.

This PR switches jobtastic to support `cachelib` instead of `werkzeug.contrib.cache`. 